### PR TITLE
added quantum cron to change the feature flags every 1 hour to active…

### DIFF
--- a/src/featureflagservice/config/config.exs
+++ b/src/featureflagservice/config/config.exs
@@ -39,6 +39,27 @@ config :logger, :console,
 config :logger,
   level: :debug
 
+# Configure Quantum scheduler for Featureflagservice
+config :featureflagservice, Featureflagservice.Scheduler,
+  jobs: [
+    # Every 1 hour, set the feature flag to 1.0 for cartServiceFailure
+    {"0 */1 * * *", {Featureflagservice.FeatureFlags, :toggle_feature_flag, ["cartServiceFailure", 1.0]}},
+    # Every 30 minutes, set the feature flag to 0.0 for cartServiceFailure
+    {"*/30 * * * *", {Featureflagservice.FeatureFlags, :toggle_feature_flag, ["cartServiceFailure", 0.0]}},
+    # Every 1 hour, set the feature flag to 1.0 for productCatalogFailure
+    {"0 */1 * * *", {Featureflagservice.FeatureFlags, :toggle_feature_flag, ["productCatalogFailure", 1.0]}},
+    # Every 30 minutes, set the feature flag to 0.0 for productCatalogFailure
+    {"*/30 * * * *", {Featureflagservice.FeatureFlags, :toggle_feature_flag, ["productCatalogFailure", 0.0]}},
+    # Every 1 hour, set the feature flag to 1.0 for recommendationCache
+    {"0 */1 * * *", {Featureflagservice.FeatureFlags, :toggle_feature_flag, ["recommendationCache", 1.0]}},
+    # Every 30 minutes, set the feature flag to 0.0 for recommendationCache
+    {"*/30 * * * *", {Featureflagservice.FeatureFlags, :toggle_feature_flag, ["recommendationCache", 0.0]}},
+    # Every 1 hour, set the feature flag to 1.0 for adServiceFailure
+    {"0 */1 * * *", {Featureflagservice.FeatureFlags, :toggle_feature_flag, ["adServiceFailure", 1.0]}},
+    # Every 30 minutes, set the feature flag to 0.0 for adServiceFailure
+    {"*/30 * * * *", {Featureflagservice.FeatureFlags, :toggle_feature_flag, ["adServiceFailure", 0.0]}}
+  ]
+
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 

--- a/src/featureflagservice/lib/featureflagservice/application.ex
+++ b/src/featureflagservice/lib/featureflagservice/application.ex
@@ -1,10 +1,4 @@
-# Copyright The OpenTelemetry Authors
-# SPDX-License-Identifier: Apache-2.0
-
-
 defmodule Featureflagservice.Application do
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
   @moduledoc false
 
   use Application
@@ -20,7 +14,8 @@ defmodule Featureflagservice.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: Featureflagservice.PubSub},
       # Start the Endpoint (http/https)
-      FeatureflagserviceWeb.Endpoint
+      FeatureflagserviceWeb.Endpoint,
+      Featureflagservice.Scheduler
       # Start a worker by calling: Featureflagservice.Worker.start_link(arg)
       # {Featureflagservice.Worker, arg}
     ]
@@ -31,8 +26,6 @@ defmodule Featureflagservice.Application do
     Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
   @impl true
   def config_change(changed, _new, removed) do
     FeatureflagserviceWeb.Endpoint.config_change(changed, removed)

--- a/src/featureflagservice/lib/featureflagservice/feature_flag_scheduler.ex
+++ b/src/featureflagservice/lib/featureflagservice/feature_flag_scheduler.ex
@@ -1,0 +1,3 @@
+defmodule Featureflagservice.Scheduler do
+  use Quantum, otp_app: :featureflagservice
+end

--- a/src/featureflagservice/lib/featureflagservice/feature_flags.ex
+++ b/src/featureflagservice/lib/featureflagservice/feature_flags.ex
@@ -130,4 +130,29 @@ defmodule Featureflagservice.FeatureFlags do
   def change_feature_flag(%FeatureFlag{} = feature_flag, attrs \\ %{}) do
     FeatureFlag.changeset(feature_flag, attrs)
   end
+
+  # Public function to toggle the feature flag
+  def toggle_feature_flag(name, value) do
+    feature_flag = get_feature_flag_by_name(name)
+
+    case feature_flag do
+      nil ->
+        {:error, :not_found}
+      %FeatureFlag{} ->
+        update_feature_flag(feature_flag, %{enabled: value})
+    end
+  end
+
+  # Private function to toggle the feature flag
+  defp toggle_feature_flag(name) do
+    feature_flag = get_feature_flag_by_name(name)
+
+    new_value = case feature_flag.enabled do
+      0.0 -> 1.0
+      1.0 -> 0.0
+      _ -> feature_flag.enabled
+    end
+
+    update_feature_flag(feature_flag, %{enabled: new_value})
+  end
 end

--- a/src/featureflagservice/mix.exs
+++ b/src/featureflagservice/mix.exs
@@ -64,7 +64,8 @@ defmodule Featureflagservice.MixProject do
       {:opentelemetry_api, "~> 1.2.1"},
       {:opentelemetry, "~> 1.3.0"},
       {:opentelemetry_phoenix, "~> 1.1.1"},
-      {:opentelemetry_ecto, "~> 1.1.1"}
+      {:opentelemetry_ecto, "~> 1.1.1"},
+      {:quantum, "~> 3.5.3"}
     ]
   end
 


### PR DESCRIPTION
… and change back to every 30 minutes. this can be modified in the src/featureflagservice/config/config.exs

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
